### PR TITLE
enable edit from page directly

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: 通过源码分析 Node.js 原理
 
 repo_name: understand-nodejs
 repo_url: https://github.com/theanarkh/understand-nodejs
-edit_uri: edit/main/docs/
+edit_uri: edit/master/docs/
 
 copyright: Copyright &copy; 2021 theanarkh
 


### PR DESCRIPTION
enable edit from page directly, and our default branch is `master` instead of `main`

![image](https://user-images.githubusercontent.com/44063249/134361936-861fa6ff-6380-45b4-8be6-d08d344225d2.png)
